### PR TITLE
Admin promotion and demotion logic

### DIFF
--- a/src/internal/db/migrations.go
+++ b/src/internal/db/migrations.go
@@ -13,6 +13,7 @@ func Migrate() {
 		&models.RefreshToken{},
 		&models.Event{},
 		&models.EventUser{},
+		&models.AdminStatus{},
 	)
 	if err != nil {
 		log.Fatalf("migrations failed: %v", err)

--- a/src/internal/handlers/event_handler.go
+++ b/src/internal/handlers/event_handler.go
@@ -19,7 +19,7 @@ func NewEventHandler(service *services.EventService) *EventHandler {
 func (h *EventHandler) CreateEvent(w http.ResponseWriter, r *http.Request) {
 	var event models.Event
 	if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
-		u.Send(w, "Erro ao ler JSON", nil, http.StatusBadRequest)
+		u.Send(w, "Error parsing response body: "+err.Error(), nil, http.StatusBadRequest)
 		return
 	}
 
@@ -202,4 +202,58 @@ func (h *EventHandler) GetEventAtendeesBySlug(w http.ResponseWriter, r *http.Req
 	}
 
 	u.Send(w, "", atendees, http.StatusOK)
+}
+
+func (h *EventHandler) PromoteUserOfEventBySlug(w http.ResponseWriter, r *http.Request) {
+	claims := u.GetUserFromContext(r.Context())
+	slug := r.PathValue("slug")
+	if slug == "" {
+		u.Send(w, "slug não pode ser vazio", nil, http.StatusBadRequest)
+		return
+	}
+
+	type emailBody struct {
+		Email string `json:"email"`
+	}
+
+	var body emailBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		u.Send(w, "Erro ao ler JSON"+err.Error(), nil, http.StatusBadRequest)
+		return
+	}
+
+	err := h.EventService.PromoteUserOfEventBySlug(body.Email, claims.ID, slug)
+	if err != nil {
+		u.Send(w, err.Error(), nil, http.StatusBadRequest)
+		return
+	}
+
+	u.Send(w, "User of event "+slug+" promoted", nil, http.StatusOK)
+}
+
+func (h *EventHandler) DemoteUserOfEventBySlug(w http.ResponseWriter, r *http.Request) {
+	claims := u.GetUserFromContext(r.Context())
+	slug := r.PathValue("slug")
+	if slug == "" {
+		u.Send(w, "slug não pode ser vazio", nil, http.StatusBadRequest)
+		return
+	}
+
+	type emailBody struct {
+		Email string `json:"email"`
+	}
+
+	var body emailBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		u.Send(w, "Erro ao ler JSON"+err.Error(), nil, http.StatusBadRequest)
+		return
+	}
+
+	err := h.EventService.DemoteUserOfEventBySlug(body.Email, claims.ID, slug)
+	if err != nil {
+		u.Send(w, err.Error(), nil, http.StatusBadRequest)
+		return
+	}
+
+	u.Send(w, "User of event "+slug+" demoted", nil, http.StatusOK)
 }

--- a/src/internal/models/event.go
+++ b/src/internal/models/event.go
@@ -8,17 +8,13 @@ import (
 
 type Event struct {
 	gorm.Model
-	ID          string    `gorm:"type:varchar(36);primaryKey;"`
-	Slug        string    `gorm:"type:varchar(100);primaryKey"`
-	Name        string    `gorm:"type:varchar(100);not null"`
-	Description string    `gorm:"not null"`
-	Location    string    `gorm:"not null"`
+	ID          string `gorm:"type:varchar(36);primaryKey;"`
+	Slug        string `gorm:"type:varchar(100);primaryKey"`
+	Name        string `gorm:"type:varchar(100);not null"`
+	Description string
+	Location    string
 	StartDate   time.Time `gorm:"not null" json:"start_date"`
 	EndDate     time.Time `gorm:"not null" json:"end_date"`
-	Redes       string    `gorm:"not null"`
-
-	// Decidir como funciona o pagamento
-	// Price    string    `gorm:"not null"`
 
 	Atendees []User `gorm:"many2many:event_users;constraint:OnDelete:CASCADE"`
 }

--- a/src/internal/models/user.go
+++ b/src/internal/models/user.go
@@ -7,25 +7,37 @@ import (
 
 type User struct {
 	gorm.Model
-	ID       string `gorm:"type:varchar(36);primaryKey;"`
-	Name     string `gorm:"not null"`
-	LastName string `gorm:"not null" json:"last_name"`
-	Event    string `gorm:"not null"`
-	Email    string `gorm:"unique;not null"`
-	Password string `gorm:"not null"`
-
-	IsMasterUser  bool `json:"is_master_user"`
-	IsMasterAdmin bool `json:"is_master_admin"`
-	IsAdmin       bool `json:"is_admin"`
-
+	ID         string `gorm:"type:varchar(36);primaryKey;"`
+	Name       string `gorm:"not null"`
+	LastName   string `gorm:"not null" json:"last_name"`
+	Email      string `gorm:"unique;not null"`
+	Password   string `gorm:"not null"`
 	IsVerified bool   `json:"is_verified"`
-	IsUenf     bool   `json:"is_uenf"`
-	Curso      string `json:"curso"`
-	Periodo    string `json:"periodo"`
-	Redes      string `json:"redes"`
+
+	IsMasterUser bool `json:"is_master_user"`
+
+	// Maybe do these
+	// IsUenf  bool   `json:"is_uenf"`
+	// Curso   string `json:"curso"`
+	// Periodo string `json:"periodo"`
 
 	Events []Event        `gorm:"many2many:event_users;constraint:OnDelete:CASCADE"`
 	Tokens []RefreshToken `gorm:"foreignKey:UserID;constrainth:OnDelete:CASCADE"`
+}
+
+type AdminType string
+
+const (
+	AdminTypeMaster AdminType = "master_admin"
+	AdminTypeNormal AdminType = "admin"
+)
+
+type AdminStatus struct {
+	gorm.Model
+	UserID    string    `gorm:"type:varchar(36)"`
+	EventID   string    `gorm:"type:varchar(36)"`
+	EventSlug string    `gorm:"type:varchar(100)"`
+	AdminType AdminType `gorm:"type:varchar(20)"`
 }
 
 type UserRegister struct {
@@ -49,10 +61,11 @@ type RefreshToken struct {
 }
 
 type UserClaims struct {
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	LastName string `json:"last_name"`
-	Event    string `json:"event"`
-	IsPaid   bool   `json:"is_paid"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Email       string `json:"email"`
+	LastName    string `json:"last_name"`
+	IsVerified  bool   `json:"is_verified"`
+	AdminStatus string `json:"admin_status"`
 	jwt.RegisteredClaims
 }

--- a/src/internal/repos/authRepo.go
+++ b/src/internal/repos/authRepo.go
@@ -36,14 +36,12 @@ func (r *AuthRepo) CreateMasterUser() {
 	}
 
 	MasterUser := &models.User{
-		ID:            uuid.New().String(),
-		Name:          "Master",
-		LastName:      "User",
-		Email:         config.GetSystemEmail(),
-		Password:      "$2a$10$ON3gg.Zb/MV7.l/LtYvEUeXxVP4LAKdo/VU1rXXUBxX68LODE5Z7y",
-		IsMasterUser:  true,
-		IsMasterAdmin: true,
-		IsAdmin:       true,
+		ID:           uuid.New().String(),
+		Name:         "Master",
+		LastName:     "User",
+		Email:        config.GetSystemEmail(),
+		Password:     "$2a$10$ON3gg.Zb/MV7.l/LtYvEUeXxVP4LAKdo/VU1rXXUBxX68LODE5Z7y",
+		IsMasterUser: true,
 	}
 
 	err = r.DB.Create(MasterUser).Error
@@ -116,4 +114,13 @@ func (r *AuthRepo) DeleteRefreshToken(userID, tokenStr string) error {
 	return r.DB.
 		Where("user_id = ? AND token_str = ?", userID, tokenStr).
 		Delete(&models.RefreshToken{}).Error
+}
+
+func (r *AuthRepo) GetAllAdminStatusFromUser(userID string) ([]models.AdminStatus, error) {
+	var adminStatuses []models.AdminStatus
+	err := r.DB.Where("user_id = ?", userID).Find(&adminStatuses).Error
+	if err != nil {
+		return nil, err
+	}
+	return adminStatuses, nil
 }

--- a/src/internal/repos/event_repo.go
+++ b/src/internal/repos/event_repo.go
@@ -1,6 +1,7 @@
 package repos
 
 import (
+	"errors"
 	"scti/internal/models"
 
 	"gorm.io/gorm"
@@ -89,6 +90,14 @@ func (r *EventRepo) GetUserByID(userID string) (models.User, error) {
 	return user, nil
 }
 
+func (r *EventRepo) GetUserByEmail(email string) (models.User, error) {
+	var user models.User
+	if err := r.DB.Where("email = ?", email).First(&user).Error; err != nil {
+		return models.User{}, err
+	}
+	return user, nil
+}
+
 func (r *EventRepo) ExistsUserByID(userID string) (bool, error) {
 	var user models.User
 	if err := r.DB.Where("id = ?", userID).First(&user).Error; err != nil {
@@ -143,4 +152,111 @@ func (r *EventRepo) GetEventAtendeesBySlug(slug string) (*[]models.EventUser, er
 	}
 
 	return &eventUsers, nil
+}
+
+func (r *EventRepo) GetAtendeeByIDAndSlug(userID, slug string) (*models.EventUser, error) {
+	var eventUser *models.EventUser
+	if err := r.DB.Where("user_id = ? and event_slug = ?", userID, slug).First(&eventUser).Error; err != nil {
+		return nil, err
+	}
+	return eventUser, nil
+}
+
+func (r *EventRepo) IsUserRegistered(userID string, slug string) (bool, error) {
+	var eventUser models.EventUser
+	if err := r.DB.Where("user_id = ? AND event_slug = ?", userID, slug).First(&eventUser).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func (r *EventRepo) GetUserAdminStatusBySlug(userID string, slug string) (*models.AdminStatus, error) {
+	var adminStatus models.AdminStatus
+	if err := r.DB.Where("user_id = ? AND event_slug = ?", userID, slug).First(&adminStatus).Error; err != nil {
+		return nil, err
+	}
+	return &adminStatus, nil
+}
+
+func (r *EventRepo) MakeAdminOfEventBySlug(userID string, slug string) error {
+	var event models.Event
+	if err := r.DB.Where("slug = ?", slug).First(&event).Error; err != nil {
+		return err
+	}
+
+	adminStatus := models.AdminStatus{
+		UserID:    userID,
+		EventID:   event.ID,
+		EventSlug: event.Slug,
+		AdminType: models.AdminTypeNormal,
+	}
+
+	if err := r.DB.Create(&adminStatus).Error; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *EventRepo) PromoteUserOfEventBySlug(userID string, slug string) error {
+	var adminStatus models.AdminStatus
+	if err := r.DB.Where("user_id = ? AND event_slug = ?", userID, slug).First(&adminStatus).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return errors.New("a user that is not an admin can't be promoted")
+		}
+		return err
+	}
+
+	if adminStatus.AdminType == models.AdminTypeMaster {
+		return errors.New("user is already a master admin")
+	}
+
+	adminStatus.AdminType = models.AdminTypeMaster
+
+	if err := r.DB.Save(&adminStatus).Error; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *EventRepo) DemoteUserOfEventBySlug(userID, slug string) error {
+	var adminStatus models.AdminStatus
+	if err := r.DB.Where("user_id = ? AND event_slug = ?", userID, slug).First(&adminStatus).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return errors.New("a user that is not an admin can't be demoted")
+		}
+		return err
+	}
+
+	if adminStatus.AdminType == models.AdminTypeNormal {
+		return errors.New("user is already a normal admin")
+	}
+
+	adminStatus.AdminType = models.AdminTypeNormal
+
+	if err := r.DB.Save(&adminStatus).Error; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *EventRepo) RemoveAdminOfEventBySlug(userID string, slug string) error {
+	var adminStatus models.AdminStatus
+	if err := r.DB.Where("user_id = ? AND event_slug = ?", userID, slug).First(&adminStatus).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return errors.New("user already not an admin")
+		}
+		return err
+	}
+
+	if err := r.DB.Delete(&adminStatus).Error; err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/src/main.go
+++ b/src/main.go
@@ -52,16 +52,19 @@ func initializeMux(database *gorm.DB, cfg *config.Config) *http.ServeMux {
 	mux.Handle("POST /secure-verify-tokens", authMiddleware(http.HandlerFunc(authHandler.VerifyJWT)))
 
 	// Event routes
+	mux.HandleFunc("GET /events", eventHandler.GetAllEvents)
+	mux.HandleFunc("GET /events/{slug}", eventHandler.GetEventBySlug)
 	mux.Handle("POST /events", authMiddleware(http.HandlerFunc(eventHandler.CreateEvent)))
 	mux.Handle("PATCH /events", authMiddleware(http.HandlerFunc(eventHandler.UpdateEvent)))
 	mux.Handle("PATCH /events/{slug}", authMiddleware(http.HandlerFunc(eventHandler.UpdateEventBySlug)))
 	mux.Handle("DELETE /events/{slug}", authMiddleware(http.HandlerFunc(eventHandler.DeleteEventBySlug)))
-	mux.HandleFunc("GET /events", eventHandler.GetAllEvents)
-	mux.HandleFunc("GET /events/{slug}", eventHandler.GetEventBySlug)
 	mux.Handle("POST /events/{slug}/attend", authMiddleware(http.HandlerFunc(eventHandler.RegisterToEvent)))
 	mux.Handle("POST /events/{slug}/unattend", authMiddleware(http.HandlerFunc(eventHandler.UnregisterToEvent)))
 	mux.Handle("GET /events/{slug}/attendees", authMiddleware(http.HandlerFunc(eventHandler.GetEventAtendeesBySlug)))
-	// mux.Handle("POST /events/{slug}/pay", authMiddleware(http.HandlerFunc(eventHandler.PayEvent)))
+
+	// Admin routes
+	mux.Handle("POST /events/{slug}/promote", authMiddleware(http.HandlerFunc(eventHandler.PromoteUserOfEventBySlug)))
+	mux.Handle("POST /events/{slug}/demote", authMiddleware(http.HandlerFunc(eventHandler.DemoteUserOfEventBySlug)))
 
 	return mux
 }


### PR DESCRIPTION
A master user is now able to create admins
- A user can be made an admin for an event that user is in
- An admin can be promoted to master_admin
- An admin can't create or promote admins
- Master admins can make admins
- Master admins can't promote admins to master admins
- Master admins can't demote master admins
- Master admins can't be promoted to master user
- Admins can be demoted of their roles even after unregistering from the event in question