### PR TITLE
Added Refresh token parameter to API documentation and removed unused…

### DIFF
--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -3254,6 +3254,13 @@ const docTemplate = `{
                         "required": true
                     },
                     {
+                        "type": "string",
+                        "description": "Bearer {refresh_token}",
+                        "name": "Refresh",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
                         "description": "Create event creator request",
                         "name": "request",
                         "in": "body",
@@ -3272,18 +3279,6 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/handlers.AuthStandardErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/handlers.AuthStandardErrorResponse"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/handlers.AuthStandardErrorResponse"
                         }

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -3248,6 +3248,13 @@
                         "required": true
                     },
                     {
+                        "type": "string",
+                        "description": "Bearer {refresh_token}",
+                        "name": "Refresh",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
                         "description": "Create event creator request",
                         "name": "request",
                         "in": "body",
@@ -3266,18 +3273,6 @@
                     },
                     "400": {
                         "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/handlers.AuthStandardErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/handlers.AuthStandardErrorResponse"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/handlers.AuthStandardErrorResponse"
                         }

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -2854,6 +2854,11 @@ paths:
         name: Authorization
         required: true
         type: string
+      - description: Bearer {refresh_token}
+        in: header
+        name: Refresh
+        required: true
+        type: string
       - description: Create event creator request
         in: body
         name: request
@@ -2869,14 +2874,6 @@ paths:
             $ref: '#/definitions/handlers.NoMessageSuccessResponse'
         "400":
           description: Bad Request
-          schema:
-            $ref: '#/definitions/handlers.AuthStandardErrorResponse'
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/handlers.AuthStandardErrorResponse'
-        "403":
-          description: Forbidden
           schema:
             $ref: '#/definitions/handlers.AuthStandardErrorResponse'
       security:

--- a/src/internal/handlers/users_handler.go
+++ b/src/internal/handlers/users_handler.go
@@ -26,11 +26,10 @@ type CreateEventCreatorRequest struct {
 // @Produce      json
 // @Security     Bearer
 // @Param        Authorization header string true "Bearer {access_token}"
+// @Param        Refresh header string true "Bearer {refresh_token}"
 // @Param        request body CreateEventCreatorRequest true "Create event creator request"
 // @Success      200  {object}  NoMessageSuccessResponse
 // @Failure      400  {object}  AuthStandardErrorResponse
-// @Failure      401  {object}  AuthStandardErrorResponse
-// @Failure      403  {object}  AuthStandardErrorResponse
 // @Router       /users/create-event-creator [post]
 func (h *UsersHandler) CreateEventCreator(w http.ResponseWriter, r *http.Request) {
 	user, err := getUserFromContext(h.UserService.UserRepo.GetUserByID, r)

--- a/src/internal/services/product_service.go
+++ b/src/internal/services/product_service.go
@@ -21,6 +21,7 @@ func NewProductService(repo *repos.ProductRepo) *ProductService {
 
 // TODO: Integrate bundled products
 // TODO: Verify if the access targets are valid
+// TODO: Event access target should give access to all activities in the event
 func (s *ProductService) CreateEventProduct(user models.User, eventSlug string, req models.ProductRequest) (*models.Product, error) {
 	event, err := s.ProductRepo.GetEventBySlug(eventSlug)
 	if err != nil {


### PR DESCRIPTION
… error responses for CreateEventCreator endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated API documentation to require a "Refresh" header (Bearer {refresh_token}) for the POST /users/create-event-creator endpoint.
  - Removed explicit documentation of "401 Unauthorized" and "403 Forbidden" responses for this endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->